### PR TITLE
End of day api

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,10 @@ This document contains critical information about working with this codebase. Fo
     - Document with docstrings
     - Use f-strings for formatting
 
+
+## TypeDicts
+Do not return `dict[str, int]`  but instead return TypeDict classes that define the attributes please.
+
 ## Development Philosophy
 
 - **Simplicity**: Write simple, straightforward code
@@ -73,3 +77,5 @@ This document contains critical information about working with this codebase. Fo
 - test data is created in the @tests folder
 - tests utilize `*_mock.py` files to mock out the data from `repos` and `data_sources`
 
+
+ 

--- a/src/cmd/ingest_all_EOD_for_historical_tickers.py
+++ b/src/cmd/ingest_all_EOD_for_historical_tickers.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Ingest All EOD Historical Pricing Data
+
+Fetches and ingests complete historical end-of-day pricing data for all ticker
+symbols found in the ticker_history table (includes active and delisted tickers).
+
+Usage:
+    python -m src.cmd.ingest_all_EOD_for_historical_tickers
+
+    or
+
+    python src/cmd/ingest_all_EOD_for_historical_tickers.py
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+from src.pipelines.eod_pricing_pipeline import EodPricingPipeline
+from src.repos.equities.tickers.ticker_history_repository import TickerHistoryRepository
+
+
+def setup_logging() -> None:
+    """Set up logging configuration."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        handlers=[logging.StreamHandler()],
+    )
+
+
+def main() -> int:
+    """Ingest EOD pricing data for all historical tickers."""
+    setup_logging()
+    logger = logging.getLogger(__name__)
+
+    try:
+        # Initialize repositories and pipeline
+        ticker_history_repo = TickerHistoryRepository()
+        pipeline = EodPricingPipeline()
+
+        # Step 1: Get all ticker history records
+        print("\n" + "=" * 70)
+        print("EOD HISTORICAL PRICING DATA INGESTION")
+        print("=" * 70)
+        print("\nFetching all ticker symbols from ticker_history table...")
+
+        all_ticker_histories = ticker_history_repo.get_all_ticker_histories()
+        logger.info(f"Retrieved {len(all_ticker_histories)} ticker history records")
+
+        # Extract unique symbols
+        unique_symbols = sorted(set(th.symbol for th in all_ticker_histories))
+        total_symbols = len(unique_symbols)
+
+        print(f"Found {total_symbols:,} unique ticker symbols to process")
+        print(f"This includes both active and delisted tickers\n")
+
+        # Tracking variables
+        successful_count = 0
+        failed_count = 0
+        total_records_inserted = 0
+        failed_tickers: list[tuple[str, str]] = []
+
+        # Step 2: Process each symbol
+        for idx, symbol in enumerate(unique_symbols, start=1):
+            print(f"\n[{idx}/{total_symbols}] Processing {symbol}...")
+
+            try:
+                # Fetch and insert pricing data (no date limits = full history)
+                result = pipeline.ingest_pricing_for_ticker(symbol)
+
+                if result["errors"] > 0:
+                    logger.error(
+                        f"Error ingesting data for {symbol}: "
+                        f"ticker_id={result['ticker_id']}"
+                    )
+                    failed_count += 1
+                    failed_tickers.append((symbol, "Ingestion error"))
+                else:
+                    successful_count += 1
+                    total_records_inserted += result["upserted"]
+                    logger.info(
+                        f"✓ {symbol}: Inserted {result['upserted']:,} records "
+                        f"({result['from_date']} to {result['to_date']})"
+                    )
+
+            except Exception as e:
+                logger.error(f"Unexpected error processing {symbol}: {e}")
+                failed_count += 1
+                failed_tickers.append((symbol, str(e)))
+
+        # Step 3: Print summary
+        print("\n" + "=" * 70)
+        print("INGESTION SUMMARY")
+        print("=" * 70)
+        print(f"  Total tickers processed: {total_symbols:,}")
+        print(f"  Successful: {successful_count:,}")
+        print(f"  Failed: {failed_count:,}")
+        print(f"  Total pricing records inserted: {total_records_inserted:,}")
+        print("-" * 70)
+
+        if failed_tickers:
+            print(f"\n⚠️  {failed_count} ticker(s) failed:")
+            for symbol, error in failed_tickers[:10]:  # Show first 10
+                print(f"    - {symbol}: {error}")
+            if len(failed_tickers) > 10:
+                print(f"    ... and {len(failed_tickers) - 10} more")
+
+        if failed_count > 0:
+            print("\n⚠️  Some tickers failed. Check the logs for details.")
+            return 1
+        else:
+            print("\n✅ All tickers processed successfully!")
+            return 0
+
+    except KeyboardInterrupt:
+        print("\n❌ Cancelled by user")
+        return 1
+
+    except Exception as e:
+        logger.exception(f"Fatal error during ingestion: {e}")
+        print(f"\n❌ Fatal error: {e}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/database/equities/migrations/versions/ebbbc3162c18_add_historical_eod_pricing_table.py
+++ b/src/database/equities/migrations/versions/ebbbc3162c18_add_historical_eod_pricing_table.py
@@ -1,0 +1,72 @@
+"""add_historical_eod_pricing_table
+
+Revision ID: ebbbc3162c18
+Revises: 908a36c712dc
+Create Date: 2025-11-08 21:36:22.372231
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'ebbbc3162c18'
+down_revision: Union[str, Sequence[str], None] = '908a36c712dc'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Create historical_eod_pricing table
+    op.create_table(
+        "historical_eod_pricing",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("ticker_id", sa.Integer(), nullable=False),
+        sa.Column("date", sa.Date(), nullable=False),
+        sa.Column("open", sa.BigInteger(), nullable=False),
+        sa.Column("high", sa.BigInteger(), nullable=False),
+        sa.Column("low", sa.BigInteger(), nullable=False),
+        sa.Column("close", sa.BigInteger(), nullable=False),
+        sa.Column("adjusted_close", sa.BigInteger(), nullable=False),
+        sa.Column("volume", sa.BigInteger(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["ticker_id"],
+            ["tickers.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("ticker_id", "date", name="uq_ticker_date"),
+        comment="Historical end-of-day pricing data with prices stored as integers (×10,000)",
+    )
+
+    # Create indexes
+    op.create_index(
+        op.f("ix_historical_eod_pricing_ticker_id"),
+        "historical_eod_pricing",
+        ["ticker_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_historical_eod_pricing_date"),
+        "historical_eod_pricing",
+        ["date"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # Drop indexes
+    op.drop_index(
+        op.f("ix_historical_eod_pricing_date"), table_name="historical_eod_pricing"
+    )
+    op.drop_index(
+        op.f("ix_historical_eod_pricing_ticker_id"),
+        table_name="historical_eod_pricing",
+    )
+
+    # Drop table
+    op.drop_table("historical_eod_pricing")

--- a/src/database/equities/tables/README.md
+++ b/src/database/equities/tables/README.md
@@ -1,0 +1,41 @@
+# Equities Database Tables
+
+## Company
+Core company information that persists over time.
+- **Fields**: id, company_name, exchange, sector, industry, country, market_cap, description, active, source, created_at, updated_at
+- **Associations**: Has many Tickers, Has many Ticker History records
+
+## Ticker
+Maps currently active ticker symbols to companies.
+- **Fields**: id, symbol (unique), company_id, created_at, updated_at
+- **Associations**: Belongs to Company, Has many Historical EOD Pricing records
+- **Purpose**: Active symbol-to-company mapping
+
+## Ticker History
+Tracks all ticker symbols over time, including delisted ones.
+- **Fields**: id, symbol, company_id, valid_from, valid_to, active, created_at, updated_at
+- **Associations**: Belongs to Company
+- **Purpose**: Historical symbol tracking with temporal validity
+
+## Historical EOD Pricing
+End-of-day OHLCV pricing data for tickers.
+- **Fields**: id, ticker_id, date, open, high, low, close, adjusted_close, volume
+- **Associations**: Belongs to Ticker
+- **Constraints**: Unique (ticker_id, date)
+- **Indexes**: ticker_id, date
+- **Price Storage**: Prices stored as BIGINT (multiply by 10,000): $1.00 = 10,000
+- **Purpose**: Historical pricing data linked to ticker symbols
+
+## Relationships
+```
+Company (1) ←→ (many) Ticker
+Company (1) ←→ (many) Ticker History
+Ticker (1) ←→ (many) Historical EOD Pricing
+```
+
+## Delisted Symbols
+Delisted companies tracked via:
+- Company.active = False
+- Ticker History.valid_to = delisting date
+- Historical EOD Pricing remains linked via ticker_id (CASCADE on delete)
+

--- a/src/database/equities/tables/__init__.py
+++ b/src/database/equities/tables/__init__.py
@@ -1,0 +1,8 @@
+"""Database table models for equities."""
+
+from src.database.equities.tables.company import Company
+from src.database.equities.tables.historical_eod_pricing import HistoricalEodPricing
+from src.database.equities.tables.ticker import Ticker
+from src.database.equities.tables.ticker_history import TickerHistory
+
+__all__ = ["Company", "HistoricalEodPricing", "Ticker", "TickerHistory"]

--- a/src/database/equities/tables/historical_eod_pricing.py
+++ b/src/database/equities/tables/historical_eod_pricing.py
@@ -1,0 +1,123 @@
+"""SQLAlchemy Historical EOD Pricing table for database operations."""
+
+from __future__ import annotations
+
+from datetime import date as date_type
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+from sqlalchemy import BigInteger, Date, ForeignKey, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.data_sources.models.historical_eod_pricing import (
+    HistoricalEndOfDayPricing as HistoricalEodPricingDataModel,
+)
+from src.database.equities.base import Base
+
+# Import for relationship type hint
+if TYPE_CHECKING:
+    from src.database.equities.tables.ticker import Ticker
+
+# Price multiplier constant: $1.00 = 10,000 (4 decimal places)
+PRICE_MULTIPLIER = 10000
+
+
+class HistoricalEodPricing(Base):
+    """SQLAlchemy model for historical end-of-day pricing data.
+
+    Prices are stored as integers multiplied by 10,000 for precision.
+    Example: $63.68 is stored as 636,800.
+    """
+
+    __tablename__ = "historical_eod_pricing"
+
+    # Primary key with auto-incrementing serial ID
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+
+    # Foreign key to ticker
+    ticker_id: Mapped[int] = mapped_column(
+        ForeignKey("tickers.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+
+    # Trading date
+    date: Mapped[date_type] = mapped_column(Date, nullable=False, index=True)
+
+    # OHLC prices (stored as BIGINT, multiply by 10,000)
+    open: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    high: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    low: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    close: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    adjusted_close: Mapped[int] = mapped_column(BigInteger, nullable=False)
+
+    # Volume
+    volume: Mapped[int] = mapped_column(BigInteger, nullable=False)
+
+    # Relationships
+    ticker: Mapped[Ticker] = relationship("Ticker")
+
+    # Constraints
+    __table_args__ = (
+        UniqueConstraint("ticker_id", "date", name="uq_ticker_date"),
+        {"comment": "Historical end-of-day pricing data with prices stored as integers (×10,000)"},
+    )
+
+    def __repr__(self) -> str:
+        """String representation of HistoricalEodPricing."""
+        return f"<HistoricalEodPricing(id={self.id}, ticker_id={self.ticker_id}, date={self.date})>"
+
+    def to_data_model(self) -> HistoricalEodPricingDataModel:
+        """Convert SQLAlchemy model to data model.
+
+        Returns:
+            HistoricalEodPricingDataModel instance with prices as Decimals
+        """
+        return HistoricalEodPricingDataModel(
+            id=self.id,
+            date=self.date,
+            open=Decimal(self.open) / PRICE_MULTIPLIER,
+            high=Decimal(self.high) / PRICE_MULTIPLIER,
+            low=Decimal(self.low) / PRICE_MULTIPLIER,
+            close=Decimal(self.close) / PRICE_MULTIPLIER,
+            adjusted_close=Decimal(self.adjusted_close) / PRICE_MULTIPLIER,
+            volume=self.volume,
+        )
+
+    @classmethod
+    def from_data_model(
+        cls, pricing_data: HistoricalEodPricingDataModel, ticker_id: int
+    ) -> HistoricalEodPricing:
+        """Create SQLAlchemy model from data model.
+
+        Args:
+            pricing_data: HistoricalEodPricingDataModel instance
+            ticker_id: ID of the ticker this pricing data belongs to
+
+        Returns:
+            HistoricalEodPricing SQLAlchemy model instance
+        """
+        return cls(
+            ticker_id=ticker_id,
+            date=pricing_data.date,
+            open=int(pricing_data.open * PRICE_MULTIPLIER),
+            high=int(pricing_data.high * PRICE_MULTIPLIER),
+            low=int(pricing_data.low * PRICE_MULTIPLIER),
+            close=int(pricing_data.close * PRICE_MULTIPLIER),
+            adjusted_close=int(pricing_data.adjusted_close * PRICE_MULTIPLIER),
+            volume=pricing_data.volume,
+        )
+
+    def update_from_data_model(
+        self, pricing_data: HistoricalEodPricingDataModel
+    ) -> None:
+        """Update existing SQLAlchemy model from data model.
+
+        Args:
+            pricing_data: HistoricalEodPricingDataModel instance with updated data
+        """
+        self.date = pricing_data.date
+        self.open = int(pricing_data.open * PRICE_MULTIPLIER)
+        self.high = int(pricing_data.high * PRICE_MULTIPLIER)
+        self.low = int(pricing_data.low * PRICE_MULTIPLIER)
+        self.close = int(pricing_data.close * PRICE_MULTIPLIER)
+        self.adjusted_close = int(pricing_data.adjusted_close * PRICE_MULTIPLIER)
+        self.volume = pricing_data.volume

--- a/src/pipelines/__init__.py
+++ b/src/pipelines/__init__.py
@@ -1,1 +1,21 @@
 """Pipelines for data ingestion and processing."""
+
+from src.pipelines.companies.simple_pipeline import (
+    CompanyIngestionResult,
+    CompanyPipeline,
+    ComprehensiveSyncResult,
+)
+from src.pipelines.eod_pricing_pipeline import (
+    BulkPricingResult,
+    EodPricingPipeline,
+    TickerPricingResult,
+)
+
+__all__ = [
+    "CompanyPipeline",
+    "EodPricingPipeline",
+    "CompanyIngestionResult",
+    "ComprehensiveSyncResult",
+    "BulkPricingResult",
+    "TickerPricingResult",
+]

--- a/src/pipelines/eod_pricing_pipeline.py
+++ b/src/pipelines/eod_pricing_pipeline.py
@@ -1,0 +1,277 @@
+"""EOD pricing data ingestion pipeline."""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+from typing import TypedDict
+
+from src.data_sources.eodhd.eod_data import EodhdDataSource
+from src.data_sources.models.historical_eod_pricing import (
+    HistoricalEndOfDayPricing as HistoricalEodPricingDataModel,
+)
+from src.repos.equities.pricing.historical_eod_pricing_repository import (
+    HistoricalEodPricingRepository,
+)
+from src.repos.equities.tickers.ticker_repository import TickerRepository
+
+
+class TickerPricingResult(TypedDict):
+    """Result of ingesting pricing data for a single ticker."""
+
+    ticker_id: int
+    ticker_symbol: str
+    upserted: int
+    errors: int
+    from_date: str | None
+    to_date: str | None
+
+
+class BulkPricingResult(TypedDict):
+    """Result of ingesting pricing data for multiple tickers."""
+
+    total_tickers: int
+    successful_tickers: int
+    failed_tickers: int
+    total_upserted: int
+    total_errors: int
+
+
+class EodPricingPipeline:
+    """EOD pricing data ingestion pipeline with bulk operations."""
+
+    def __init__(
+        self,
+        pricing_repo: HistoricalEodPricingRepository | None = None,
+        ticker_repo: TickerRepository | None = None,
+        logger: logging.Logger | None = None,
+    ):
+        """Initialize the pipeline with repositories and logger.
+
+        Args:
+            pricing_repo: Repository for historical EOD pricing data
+            ticker_repo: Repository for ticker data
+            logger: Logger instance
+        """
+        self.pricing_repo = pricing_repo or HistoricalEodPricingRepository()
+        self.ticker_repo = ticker_repo or TickerRepository()
+        self.logger = logger or logging.getLogger(__name__)
+
+    def ingest_pricing_for_ticker(
+        self,
+        ticker_symbol: str,
+        from_date: date | None = None,
+        to_date: date | None = None,
+    ) -> TickerPricingResult:
+        """Ingest EOD pricing data for a single ticker.
+
+        Args:
+            ticker_symbol: Ticker symbol (e.g., "AAPL")
+            from_date: Start date for pricing data (None = all available)
+            to_date: End date for pricing data (None = up to present)
+
+        Returns:
+            TickerPricingResult with ingestion details
+        """
+        results: TickerPricingResult = {
+            "ticker_id": 0,
+            "ticker_symbol": ticker_symbol,
+            "upserted": 0,
+            "errors": 0,
+            "from_date": None,
+            "to_date": None,
+        }
+
+        try:
+            # 1. Get ticker from database
+            self.logger.info(f"Looking up ticker: {ticker_symbol}")
+            ticker = self.ticker_repo.get_ticker_by_symbol(ticker_symbol)
+
+            if not ticker or ticker.id is None:
+                self.logger.error(f"Ticker not found in database: {ticker_symbol}")
+                results["errors"] = 1
+                return results
+
+            results["ticker_id"] = ticker.id
+
+            # 2. Fetch pricing data from EODHD
+            self.logger.info(
+                f"Fetching pricing data for {ticker_symbol} from EODHD..."
+            )
+            data_source = EodhdDataSource()
+
+            if not data_source.is_available():
+                self.logger.error("EODHD data source is not available")
+                results["errors"] = 1
+                return results
+
+            pricing_data = data_source.get_eod_data(
+                ticker_symbol, from_date, to_date
+            )
+
+            if not pricing_data:
+                self.logger.warning(f"No pricing data found for {ticker_symbol}")
+                return results
+
+            self.logger.info(
+                f"Retrieved {len(pricing_data)} pricing records for {ticker_symbol}"
+            )
+
+            # Track date range
+            if pricing_data:
+                dates = [p.date for p in pricing_data]
+                results["from_date"] = str(min(dates))
+                results["to_date"] = str(max(dates))
+
+            # 3. Upsert pricing data to database
+            self.logger.info(f"Upserting {len(pricing_data)} pricing records...")
+            upsert_results = self.pricing_repo.bulk_upsert_pricing(
+                ticker.id, pricing_data
+            )
+
+            results["upserted"] = upsert_results["inserted"] + upsert_results["updated"]
+
+            self.logger.info(
+                f"Successfully ingested {results['upserted']} pricing records for {ticker_symbol}"
+            )
+
+        except Exception as e:
+            self.logger.error(f"Error ingesting pricing for {ticker_symbol}: {e}")
+            results["errors"] = 1
+
+        return results
+
+    def ingest_pricing_for_multiple_tickers(
+        self,
+        ticker_symbols: list[str],
+        from_date: date | None = None,
+        to_date: date | None = None,
+    ) -> BulkPricingResult:
+        """Ingest EOD pricing data for multiple tickers.
+
+        Args:
+            ticker_symbols: List of ticker symbols
+            from_date: Start date for pricing data
+            to_date: End date for pricing data
+
+        Returns:
+            BulkPricingResult with aggregate results
+        """
+        aggregate_results: BulkPricingResult = {
+            "total_tickers": len(ticker_symbols),
+            "successful_tickers": 0,
+            "failed_tickers": 0,
+            "total_upserted": 0,
+            "total_errors": 0,
+        }
+
+        self.logger.info(
+            f"Starting bulk ingestion for {len(ticker_symbols)} tickers..."
+        )
+
+        for ticker_symbol in ticker_symbols:
+            try:
+                self.logger.info(
+                    f"Processing ticker {ticker_symbol} ({ticker_symbols.index(ticker_symbol) + 1}/{len(ticker_symbols)})..."
+                )
+
+                results = self.ingest_pricing_for_ticker(
+                    ticker_symbol, from_date, to_date
+                )
+
+                if results["errors"] == 0:
+                    aggregate_results["successful_tickers"] += 1
+                    aggregate_results["total_upserted"] += results["upserted"]
+                else:
+                    aggregate_results["failed_tickers"] += 1
+                    aggregate_results["total_errors"] += 1
+
+            except Exception as e:
+                self.logger.error(f"Unexpected error processing {ticker_symbol}: {e}")
+                aggregate_results["failed_tickers"] += 1
+                aggregate_results["total_errors"] += 1
+
+        self.logger.info(
+            f"Bulk ingestion complete. Successful: {aggregate_results['successful_tickers']}, "
+            f"Failed: {aggregate_results['failed_tickers']}, "
+            f"Total upserted: {aggregate_results['total_upserted']}"
+        )
+
+        return aggregate_results
+
+    def update_latest_pricing_for_ticker(
+        self, ticker_symbol: str, days_back: int = 30
+    ) -> TickerPricingResult:
+        """Update pricing data for a ticker for the most recent period.
+
+        Useful for incremental updates rather than full historical loads.
+
+        Args:
+            ticker_symbol: Ticker symbol
+            days_back: Number of days to look back from today
+
+        Returns:
+            TickerPricingResult with update details
+        """
+        from datetime import timedelta
+
+        to_date = date.today()
+        from_date = to_date - timedelta(days=days_back)
+
+        self.logger.info(
+            f"Updating latest {days_back} days of pricing for {ticker_symbol}"
+        )
+
+        return self.ingest_pricing_for_ticker(ticker_symbol, from_date, to_date)
+
+    def backfill_pricing_for_ticker(
+        self, ticker_symbol: str, target_date: date
+    ) -> TickerPricingResult:
+        """Backfill pricing data from a target date to the latest available date in DB.
+
+        Args:
+            ticker_symbol: Ticker symbol
+            target_date: Date to start backfilling from
+
+        Returns:
+            TickerPricingResult with backfill details
+        """
+        results: TickerPricingResult = {
+            "ticker_id": 0,
+            "ticker_symbol": ticker_symbol,
+            "upserted": 0,
+            "errors": 0,
+            "from_date": None,
+            "to_date": None,
+        }
+
+        try:
+            # Get ticker
+            ticker = self.ticker_repo.get_ticker_by_symbol(ticker_symbol)
+            if not ticker or ticker.id is None:
+                self.logger.error(f"Ticker not found: {ticker_symbol}")
+                results["errors"] = 1
+                return results
+
+            # Get latest pricing date from database
+            latest_pricing = self.pricing_repo.get_latest_pricing(ticker.id)
+
+            if latest_pricing:
+                to_date = latest_pricing.date
+                self.logger.info(
+                    f"Backfilling from {target_date} to existing latest date {to_date}"
+                )
+            else:
+                to_date = date.today()
+                self.logger.info(
+                    f"No existing pricing found. Backfilling from {target_date} to {to_date}"
+                )
+
+            # Ingest pricing data
+            return self.ingest_pricing_for_ticker(ticker_symbol, target_date, to_date)
+
+        except Exception as e:
+            self.logger.error(f"Error backfilling pricing for {ticker_symbol}: {e}")
+            results["errors"] = 1
+
+        return results

--- a/src/repos/equities/__init__.py
+++ b/src/repos/equities/__init__.py
@@ -1,1 +1,15 @@
 """Equities repository package."""
+
+from src.repos.equities.companies.company_repository import CompanyRepository
+from src.repos.equities.pricing.historical_eod_pricing_repository import (
+    HistoricalEodPricingRepository,
+)
+from src.repos.equities.tickers.ticker_history_repository import TickerHistoryRepository
+from src.repos.equities.tickers.ticker_repository import TickerRepository
+
+__all__ = [
+    "CompanyRepository",
+    "HistoricalEodPricingRepository",
+    "TickerHistoryRepository",
+    "TickerRepository",
+]

--- a/src/repos/equities/pricing/__init__.py
+++ b/src/repos/equities/pricing/__init__.py
@@ -1,0 +1,7 @@
+"""Pricing repositories for equity data."""
+
+from src.repos.equities.pricing.historical_eod_pricing_repository import (
+    HistoricalEodPricingRepository,
+)
+
+__all__ = ["HistoricalEodPricingRepository"]

--- a/src/repos/equities/pricing/historical_eod_pricing_repository.py
+++ b/src/repos/equities/pricing/historical_eod_pricing_repository.py
@@ -1,0 +1,305 @@
+"""Historical EOD pricing repository for database operations."""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+
+from sqlalchemy import and_, delete, select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.exc import SQLAlchemyError
+
+from src.config.configuration import CONFIG
+from src.data_sources.models.historical_eod_pricing import (
+    HistoricalEndOfDayPricing as HistoricalEodPricingDataModel,
+)
+from src.database.equities.tables.historical_eod_pricing import (
+    HistoricalEodPricing as HistoricalEodPricingDBModel,
+)
+from src.repos.base_repository import BaseRepository, QueryOptions
+
+logger = logging.getLogger(__name__)
+
+
+class HistoricalEodPricingRepository(
+    BaseRepository[HistoricalEodPricingDataModel, HistoricalEodPricingDBModel]
+):
+    """Repository for historical EOD pricing database operations."""
+
+    def __init__(self) -> None:
+        """Initialize historical EOD pricing repository."""
+        super().__init__(
+            config_getter=CONFIG.get_equities_config,
+            db_model_class=HistoricalEodPricingDBModel,
+        )
+
+    def _create_id_filter(self, id: int) -> HistoricalEodPricingDataModel:
+        """Create a HistoricalEodPricing filter model for ID lookups."""
+        from decimal import Decimal
+        from datetime import date as date_type
+
+        return HistoricalEodPricingDataModel(
+            date=date_type(1900, 1, 1),  # Will be ignored
+            open=Decimal("0"),  # Will be ignored
+            high=Decimal("0"),  # Will be ignored
+            low=Decimal("0"),  # Will be ignored
+            close=Decimal("0"),  # Will be ignored
+            adjusted_close=Decimal("0"),  # Will be ignored
+            volume=0,  # Will be ignored
+            id=id,  # Will be used as filter
+        )
+
+    # Domain-specific methods
+
+    def get_pricing_by_ticker(
+        self,
+        ticker_id: int,
+        from_date: date | None = None,
+        to_date: date | None = None,
+        limit: int | None = None,
+    ) -> list[HistoricalEodPricingDataModel]:
+        """Get pricing data for a ticker within a date range.
+
+        Args:
+            ticker_id: ID of the ticker
+            from_date: Start date (inclusive), None for no lower bound
+            to_date: End date (inclusive), None for no upper bound
+            limit: Maximum number of records to return
+
+        Returns:
+            List of pricing data models, ordered by date descending
+        """
+        try:
+            with self._SessionLocal() as session:
+                query = select(HistoricalEodPricingDBModel).where(
+                    HistoricalEodPricingDBModel.ticker_id == ticker_id
+                )
+
+                # Apply date filters
+                if from_date:
+                    query = query.where(
+                        HistoricalEodPricingDBModel.date >= from_date
+                    )
+                if to_date:
+                    query = query.where(
+                        HistoricalEodPricingDBModel.date <= to_date
+                    )
+
+                # Order by date descending (most recent first)
+                query = query.order_by(HistoricalEodPricingDBModel.date.desc())
+
+                # Apply limit
+                if limit:
+                    query = query.limit(limit)
+
+                result = session.execute(query)
+                db_models = result.scalars().all()
+
+                data_models = [db_model.to_data_model() for db_model in db_models]
+                logger.info(
+                    f"Retrieved {len(data_models)} pricing records for ticker_id={ticker_id}"
+                )
+                return data_models
+
+        except SQLAlchemyError as e:
+            logger.error(f"Database error retrieving pricing by ticker: {e}")
+            raise
+
+    def get_latest_pricing(
+        self, ticker_id: int
+    ) -> HistoricalEodPricingDataModel | None:
+        """Get the most recent pricing data for a ticker.
+
+        Args:
+            ticker_id: ID of the ticker
+
+        Returns:
+            Most recent pricing data model, or None if no data exists
+        """
+        results = self.get_pricing_by_ticker(ticker_id, limit=1)
+        return results[0] if results else None
+
+    def get_pricing_for_date(
+        self, ticker_id: int, target_date: date
+    ) -> HistoricalEodPricingDataModel | None:
+        """Get pricing data for a specific ticker and date.
+
+        Args:
+            ticker_id: ID of the ticker
+            target_date: The specific date
+
+        Returns:
+            Pricing data model for that date, or None if not found
+        """
+        try:
+            with self._SessionLocal() as session:
+                query = select(HistoricalEodPricingDBModel).where(
+                    and_(
+                        HistoricalEodPricingDBModel.ticker_id == ticker_id,
+                        HistoricalEodPricingDBModel.date == target_date,
+                    )
+                )
+
+                result = session.execute(query)
+                db_model = result.scalar_one_or_none()
+
+                if db_model:
+                    logger.debug(
+                        f"Found pricing for ticker_id={ticker_id} on {target_date}"
+                    )
+                    return db_model.to_data_model()
+                else:
+                    logger.debug(
+                        f"No pricing found for ticker_id={ticker_id} on {target_date}"
+                    )
+                    return None
+
+        except SQLAlchemyError as e:
+            logger.error(f"Database error retrieving pricing for date: {e}")
+            raise
+
+    def bulk_upsert_pricing(
+        self,
+        ticker_id: int,
+        pricing_data: list[HistoricalEodPricingDataModel],
+    ) -> dict[str, int]:
+        """Bulk insert or update pricing data for a ticker.
+
+        Uses PostgreSQL's ON CONFLICT DO UPDATE to handle duplicates.
+        If a record with the same ticker_id and date exists, it will be updated.
+
+        Args:
+            ticker_id: ID of the ticker
+            pricing_data: List of pricing data models to upsert
+
+        Returns:
+            Dictionary with 'inserted' and 'updated' counts
+        """
+        if not pricing_data:
+            logger.info("No pricing data to upsert")
+            return {"inserted": 0, "updated": 0}
+
+        try:
+            with self._SessionLocal() as session:
+                # Convert data models to DB models
+                db_models = [
+                    HistoricalEodPricingDBModel.from_data_model(pricing, ticker_id)
+                    for pricing in pricing_data
+                ]
+
+                # Prepare values for upsert
+                values = [
+                    {
+                        "ticker_id": db_model.ticker_id,
+                        "date": db_model.date,
+                        "open": db_model.open,
+                        "high": db_model.high,
+                        "low": db_model.low,
+                        "close": db_model.close,
+                        "adjusted_close": db_model.adjusted_close,
+                        "volume": db_model.volume,
+                    }
+                    for db_model in db_models
+                ]
+
+                # Create upsert statement
+                stmt = insert(HistoricalEodPricingDBModel).values(values)
+
+                # On conflict, update all fields except ticker_id and date
+                stmt = stmt.on_conflict_do_update(
+                    constraint="uq_ticker_date",
+                    set_={
+                        "open": stmt.excluded.open,
+                        "high": stmt.excluded.high,
+                        "low": stmt.excluded.low,
+                        "close": stmt.excluded.close,
+                        "adjusted_close": stmt.excluded.adjusted_close,
+                        "volume": stmt.excluded.volume,
+                    },
+                )
+
+                result = session.execute(stmt)
+                session.commit()
+
+                # PostgreSQL doesn't provide separate insert/update counts easily
+                # So we'll just return the total as inserted
+                total = len(pricing_data)
+                logger.info(f"Upserted {total} pricing records for ticker_id={ticker_id}")
+
+                return {"inserted": total, "updated": 0}
+
+        except SQLAlchemyError as e:
+            logger.error(f"Database error in bulk_upsert_pricing: {e}")
+            raise
+
+    def delete_pricing_by_ticker(
+        self, ticker_id: int, from_date: date | None = None, to_date: date | None = None
+    ) -> int:
+        """Delete pricing data for a ticker within an optional date range.
+
+        Args:
+            ticker_id: ID of the ticker
+            from_date: Start date (inclusive), None for no lower bound
+            to_date: End date (inclusive), None for no upper bound
+
+        Returns:
+            Number of records deleted
+        """
+        try:
+            with self._SessionLocal() as session:
+                query = delete(HistoricalEodPricingDBModel).where(
+                    HistoricalEodPricingDBModel.ticker_id == ticker_id
+                )
+
+                # Apply date filters
+                if from_date:
+                    query = query.where(
+                        HistoricalEodPricingDBModel.date >= from_date
+                    )
+                if to_date:
+                    query = query.where(
+                        HistoricalEodPricingDBModel.date <= to_date
+                    )
+
+                result = session.execute(query)
+                session.commit()
+
+                deleted_count = result.rowcount
+                logger.info(
+                    f"Deleted {deleted_count} pricing records for ticker_id={ticker_id}"
+                )
+                return deleted_count
+
+        except SQLAlchemyError as e:
+            logger.error(f"Database error in delete_pricing_by_ticker: {e}")
+            raise
+
+    def get_date_range_for_ticker(self, ticker_id: int) -> tuple[date | None, date | None]:
+        """Get the min and max dates available for a ticker.
+
+        Args:
+            ticker_id: ID of the ticker
+
+        Returns:
+            Tuple of (earliest_date, latest_date), or (None, None) if no data
+        """
+        try:
+            with self._SessionLocal() as session:
+                from sqlalchemy import func
+
+                query = select(
+                    func.min(HistoricalEodPricingDBModel.date),
+                    func.max(HistoricalEodPricingDBModel.date),
+                ).where(HistoricalEodPricingDBModel.ticker_id == ticker_id)
+
+                result = session.execute(query)
+                min_date, max_date = result.one()
+
+                logger.debug(
+                    f"Date range for ticker_id={ticker_id}: {min_date} to {max_date}"
+                )
+                return (min_date, max_date)
+
+        except SQLAlchemyError as e:
+            logger.error(f"Database error in get_date_range_for_ticker: {e}")
+            raise


### PR DESCRIPTION
Added in a new table for the database
`historical_eod_pricing` to store the end of day data for a ticker.

Added in APIs for collecting the following information from `eodhd.com` requests.
1. tickers and companies via active and delisted companies
2. end of day data

added in new command to load in End Of Day Data into the database, using the data from EODhd.com
`src/cmd/ingest_all_EOD_for_historical_tickers.py`

Added in pipeline for end of day pricing,  that will sync the data from a end of day data source to the database.







